### PR TITLE
Configuration Space Node

### DIFF
--- a/igvc_ws/src/igvc_slam/CMakeLists.txt
+++ b/igvc_ws/src/igvc_slam/CMakeLists.txt
@@ -1,0 +1,206 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(igvc_slam)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+# add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  igvc_msgs
+  nav_msgs
+  std_msgs
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a exec_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   igvc_msgs#   nav_msgs#   std_msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES igvc_slam
+#  CATKIN_DEPENDS igvc_msgs nav_msgs std_msgs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+# include
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ library
+# add_library(${PROJECT_NAME}
+#   src/${PROJECT_NAME}/igvc_slam.cpp
+# )
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+# add_executable(${PROJECT_NAME}_node src/igvc_slam_node.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(${PROJECT_NAME}_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables for installation
+## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html
+# install(TARGETS ${PROJECT_NAME}_node
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark libraries for installation
+## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_libraries.html
+# install(TARGETS ${PROJECT_NAME}
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_igvc_slam.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/igvc_ws/src/igvc_slam/launch/igvc_slam_sim.launch
+++ b/igvc_ws/src/igvc_slam/launch/igvc_slam_sim.launch
@@ -1,0 +1,15 @@
+<launch>
+    <!-- Simulator Parameters -->
+    <param name="port" value="9090"/>
+
+    <!-- Run required nodes-->
+    <node name="igvc_slam_node" pkg="igvc_slam" type="igvc_slam_node.py" output="screen"/>
+    <node name="lidar_node" pkg="igvc_vision" type="lidar_node"/>
+
+    <!-- Set up the bridge to the simulator -->
+    <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" />
+
+    <!-- Run RViz -->
+    <node type="rviz" name="rviz" pkg="rviz" />
+
+</launch>

--- a/igvc_ws/src/igvc_slam/package.xml
+++ b/igvc_ws/src/igvc_slam/package.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>igvc_slam</name>
+  <version>0.0.0</version>
+  <description>The igvc_slam package</description>
+
+
+  <maintainer email="jkleiber8@gmail.com">Justin Kleiber</maintainer>
+
+
+  <license>MIT</license>
+
+
+  <author email="jkleiber8@gmail.com">Justin Kleiber</author>
+
+
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>igvc_msgs</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+
+  <build_export_depend>igvc_msgs</build_export_depend>
+  <build_export_depend>nav_msgs</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+
+  <exec_depend>igvc_msgs</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/igvc_ws/src/igvc_slam/src/igvc_slam_node.py
+++ b/igvc_ws/src/igvc_slam/src/igvc_slam_node.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+import copy
+import numpy as np
+import rospy
+
+from nav_msgs.msg import OccupancyGrid
+
+# Publishers
+config_pub = rospy.Publisher("/igvc_vision/config_space", OccupancyGrid, queue_size=10)
+
+# Configuration space map
+config_msg = OccupancyGrid()
+lidar_config_data = [0] * (200 * 200)
+lanes_camera_config_data = [0] * (200 * 200)
+
+
+
+def lidar_callback(data):
+    lidar_config_data = [0] * (200 * 200)
+
+    for x in range(200):
+        for y in range(200):
+            if data.data[x + y * 200] > 0:
+                for x_i in range(-5,6):
+                    for y_i in range(-5,6):
+                        dist = (x_i)**2 + (y_i)**2
+                        new_x = 199 - (x + x_i)
+                        new_y = 199 - (y + y_i)
+                        if 0 <= new_x < 200 and 0 <= new_y < 200 and dist <= 25:
+                            lidar_config_data[(x + x_i) + 200 * (y + y_i)] = 100
+
+    # HACK: eventually set this to be based on the map size and stuff
+    config_msg = copy.copy(data)
+
+
+
+def lanes_camera_callback():
+    pass
+
+
+# TODO: currently this whole thing is set to use the most recent map frames from each perception unit (which is fine for now). In the future the sizing will change as the map grows.
+def config_space_callback(event):
+    # TODO: Make this add the lidar config space to the camera config space
+    config_space = lidar_config_data
+
+    # Publish the configuration space
+    config_msg.data = config_space
+    config_pub.publish(config_msg)
+
+
+
+def igvc_slam_node():
+    # Set up node
+    rospy.init_node("igvc_slam_node")
+
+    # Subscribe to necessary topics
+    rospy.Subscriber("/igvc_vision/map", OccupancyGrid, lidar_callback, queue_size=1)
+
+    # Make a timer to publish configuration spaces periodically
+    rospy.Timer(rospy.Duration(secs=1), config_space_callback, oneshot=False)
+
+    # Wait for topic updates
+    rospy.spin()
+
+
+# Main setup
+if __name__ == '__main__':
+    try:
+        igvc_slam_node()
+    except rospy.ROSInterruptException:
+        pass

--- a/igvc_ws/src/igvc_slam/src/igvc_slam_node.py
+++ b/igvc_ws/src/igvc_slam/src/igvc_slam_node.py
@@ -7,7 +7,7 @@ import rospy
 from nav_msgs.msg import OccupancyGrid
 
 # Publishers
-config_pub = rospy.Publisher("/igvc_vision/config_space", OccupancyGrid, queue_size=10)
+config_pub = rospy.Publisher("/igvc_slam/config_space", OccupancyGrid, queue_size=1)
 
 # Configuration space map
 config_msg = OccupancyGrid()


### PR DESCRIPTION
Adds a configuration space node (called igvc_slam_node for when we have higher aspirations) for the path planners to use. This takes the data from the lidar node and maps it out.

Also, there is now a launch file for running the full perception stack (as it is right now). So you can launch the lidar node and the configuration space node, along with Rviz.