### PR TITLE
Only run CI when a PR is approved

### DIFF
--- a/.github/workflows/igvc_compile_test.yml
+++ b/.github/workflows/igvc_compile_test.yml
@@ -1,12 +1,13 @@
 name: IGVC Compile Test
 
 on:
-  pull_request:
-    branches:
-    - master
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   test:
+    if: github.event.review.state == 'APPROVED' && github.base_ref == 'master'
+    
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/igvc_compile_test.yml
+++ b/.github/workflows/igvc_compile_test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    if: github.event_name == 'pull_request_review' && github.event.review.state == 'APPROVED' && github.base_ref == 'master'
+    if: github.event.review.state == 'APPROVED' && github.base.ref == 'master'
     
     runs-on: ubuntu-latest
 

--- a/.github/workflows/igvc_compile_test.yml
+++ b/.github/workflows/igvc_compile_test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    if: github.event_name == 'pull_request_review' && github.event.review.state == 'APPROVED' && github.base_ref == 'master' && 
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'APPROVED' && github.base_ref == 'master'
     
     runs-on: ubuntu-latest
 

--- a/.github/workflows/igvc_compile_test.yml
+++ b/.github/workflows/igvc_compile_test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    if: github.event.review.state == 'APPROVED' && github.base.ref == 'master'
+    if: github.event.review.state == 'APPROVED' && github.event.base.ref == 'master'
     
     runs-on: ubuntu-latest
 

--- a/.github/workflows/igvc_compile_test.yml
+++ b/.github/workflows/igvc_compile_test.yml
@@ -1,12 +1,17 @@
 name: IGVC Compile Test
 
 on:
+  pull_request:
+    branches:
+    - master
+    types:
+    - opened
   pull_request_review:
     types: [submitted]
 
 jobs:
   test:
-    if: github.event.review.state == 'APPROVED' && github.base_ref == 'master'
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'APPROVED' && github.base_ref == 'master' && 
     
     runs-on: ubuntu-latest
 
@@ -16,3 +21,11 @@ jobs:
       - name: Build docker image
         run: docker build . --file Dockerfile
 
+  fail_otherwise:
+    if: github.event_name == 'pull_request'
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Try to fail
+        run: exit 1

--- a/.github/workflows/igvc_compile_test.yml
+++ b/.github/workflows/igvc_compile_test.yml
@@ -1,12 +1,6 @@
 name: IGVC Compile Test
 
 on:
-  pull_request:
-    branches:
-    - master
-    types:
-    - opened
-    - synchronize
   pull_request_review:
     types: [submitted]
 
@@ -21,12 +15,3 @@ jobs:
 
       - name: Build docker image
         run: docker build . --file Dockerfile
-
-  fail_otherwise:
-    if: github.event_name == 'pull_request'
-    
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Try to fail
-        run: exit 1

--- a/.github/workflows/igvc_compile_test.yml
+++ b/.github/workflows/igvc_compile_test.yml
@@ -6,6 +6,7 @@ on:
     - master
     types:
     - opened
+    - synchronize
   pull_request_review:
     types: [submitted]
 

--- a/.github/workflows/igvc_compile_test.yml
+++ b/.github/workflows/igvc_compile_test.yml
@@ -5,7 +5,7 @@ on:
     types: [submitted]
 
 jobs:
-  test:
+  test_after_approval:
     if: github.event.review.state == 'approved'
     
     runs-on: ubuntu-latest

--- a/.github/workflows/igvc_compile_test.yml
+++ b/.github/workflows/igvc_compile_test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    if: github.event.review.state == 'APPROVED' && github.event.base.ref == 'master'
+    if: github.event.review.state == 'approved'
     
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The CI takes too long to let it run every time a PR receives an update. We should only run it on approval.